### PR TITLE
updated regex to be less greedy on the third match

### DIFF
--- a/doxter/common/DoxterReferenceTagParser.php
+++ b/doxter/common/DoxterReferenceTagParser.php
@@ -41,8 +41,7 @@ class DoxterReferenceTagParser extends DoxterBaseParser
 	{
 		$references = implode('|', array_keys(static::$references));
 
-		return 	sprintf('/%s(%s):([a-z0-9\@\.\-\_\/]+):?(.+)?%s/i', static::$openingTag, $references, static::$closingTag);
-
+		return 	sprintf('/%s(%s):([a-z0-9\@\.\-\_\/]+):?(.*?)%s/i', static::$openingTag, $references, static::$closingTag);
 	}
 
 	/**


### PR DESCRIPTION
I used the following text for testing this manually: 

```
entry:2 - entry:3 :: {entry:2} - {entry:3} - {entry:2} - {user:1}

{entry:4} - {entry:4:url} ---- {entry:5} - {entry:5:url} ---- {entry:3} - {entry:3:url}

[entry 4]({entry:4:url}) and [entry 5]({entry:5:url}) and [entry 3]({entry:3:url})

[entry 4]({entry:4:url}) [entry 5]({entry:5:url}) [entry 3]({entry:3:url})

[entry 4]({entry:4:url})

[entry 5]({entry:5:url})
```
