### PR TITLE
Update editor to insert reference tags into textarea instead of prompt

### DIFF
--- a/doxter/resources/js/doxter.js
+++ b/doxter/resources/js/doxter.js
@@ -131,23 +131,21 @@
       },
 
       insertAtCursor: function (myField, myValue) {
-        //IE support
-        if (document.selection) {
+        // Chrome support
+        if (/chrom(e|ium)/.test(navigator.userAgent.toLowerCase())) {
+          myField.focus();
+          document.execCommand('insertText', false, myValue);
+        } else if (document.selection) {
+        // IE Support
           myField.focus();
           sel = document.selection.createRange();
           sel.text = myValue;
-        }
-        //MOZILLA and others
-        else if (myField.selectionStart || myField.selectionStart == '0') {
-          var startPos = myField.selectionStart;
-          var endPos = myField.selectionEnd;
-          myField.value = myField.value.substring(0, startPos)
-            + myValue
-            + myField.value.substring(endPos, myField.value.length);
-          myField.selectionStart = startPos + myValue.length;
-          myField.selectionEnd = startPos + myValue.length;
         } else {
-          myField.value += myValue;
+        // MOZILLA and others
+          var str = myField.value.substr(0, myField.selectionStart)
+              + myValue + myField.value.substr(myField.selectionEnd);
+
+          myField.value = str;
         }
       }
     });

--- a/doxter/resources/js/doxter.js
+++ b/doxter/resources/js/doxter.js
@@ -131,8 +131,8 @@
       },
 
       insertAtCursor: function (myField, myValue) {
-        // Chrome support
-        if (/chrom(e|ium)/.test(navigator.userAgent.toLowerCase())) {
+        // Chrome/Safari support
+        if (/applewebkit/.test(navigator.userAgent.toLowerCase())) {
           myField.focus();
           document.execCommand('insertText', false, myValue);
         } else if (document.selection) {
@@ -141,11 +141,17 @@
           sel = document.selection.createRange();
           sel.text = myValue;
         } else {
-        // MOZILLA and others
+        // Firefox and others
+          var selection = {start: myField.selectionStart, end: myField.selectionEnd};
           var str = myField.value.substr(0, myField.selectionStart)
               + myValue + myField.value.substr(myField.selectionEnd);
 
           myField.value = str;
+          myField.focus();
+
+          // Place the cursor at the end of what we just inserted
+          myField.selectionStart = selection.start + myValue.length;
+          myField.selectionEnd = selection.start + myValue.length;
         }
       }
     });

--- a/doxter/resources/js/doxter.js
+++ b/doxter/resources/js/doxter.js
@@ -62,20 +62,20 @@
         this.addListener(this.$selectGlobalButton, 'click', 'createGlobalSetSelectorModal');
       },
 
-      createSelectorModal: function (type) {
+      createSelectorModal: function (type, event, property) {
         var self = this;
         Craft.createElementSelectorModal(type,
           {
             id      : this.id + 'Select' + type + 'Modal',
             onSelect: function (elements) {
-              var tags = self.createReferenceTags(type.toLowerCase(), elements, 'image');
+              var tags = self.createReferenceTags(type.toLowerCase(), elements, property);
               self.writeToEditor(tags);
             }
           });
       },
 
       createEntrySelectorModal: function (e) {
-        this.createSelectorModal('Entry', e);
+        this.createSelectorModal('Entry', e, 'link');
         e.preventDefault();
       },
 
@@ -92,7 +92,7 @@
             multiSelect: false,
             criteria   : {kind: 'image'},
             onSelect   : function (elements) {
-              var tags = self.createReferenceTags('asset', elements, 'image');
+              var tags = self.createReferenceTags('asset', elements, 'img');
               self.writeToEditor(tags);
             }
           });
@@ -115,18 +115,40 @@
       },
 
       writeToEditor: function (text) {
-        prompt('Copy Reference Tag', text);
+        this.insertAtCursor(this.$textarea.get(0), text);
+        this.$textarea.focus();
       },
 
-      createReferenceTags: function (type, elements) {
+      createReferenceTags: function (type, elements, property) {
         var i = 0, tags = "", tag;
 
         for (; i < elements.length; i++) {
-          tag = type.toLowerCase() + ":" + elements[i].id;
+          tag = type.toLowerCase() + ":" + elements[i].id + (property? ":" + property : '');
           tags = tags + "{" + tag + "}"
         }
 
         return tags;
+      },
+
+      insertAtCursor: function (myField, myValue) {
+        //IE support
+        if (document.selection) {
+          myField.focus();
+          sel = document.selection.createRange();
+          sel.text = myValue;
+        }
+        //MOZILLA and others
+        else if (myField.selectionStart || myField.selectionStart == '0') {
+          var startPos = myField.selectionStart;
+          var endPos = myField.selectionEnd;
+          myField.value = myField.value.substring(0, startPos)
+            + myValue
+            + myField.value.substring(endPos, myField.value.length);
+          myField.selectionStart = startPos + myValue.length;
+          myField.selectionEnd = startPos + myValue.length;
+        } else {
+          myField.value += myValue;
+        }
       }
     });
 


### PR DESCRIPTION
Currently when a user uses the toolbar to insert an asset or entry (and others) the JS prompts the user for the reference tag to copy and paste into the editor. This behavior isn't intuitive for most users. This pull request updates the JS for doxter to insert the reference tag directly in the editor where the cursor is currently located.

Also updated to assume the user would like to use ":img" as reference tag for assets (e.g. {asset:190:img}) which will render the correct "<img ... >".

Also assumes the user would like to use ":link" for entry reference tags (e.g. {entry:400:link}) which will render an anchor html element linking to the entry.